### PR TITLE
Bump sdk to v0.0.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/conductorone/baton
 go 1.19
 
 require (
-	github.com/conductorone/baton-sdk v0.0.6
+	github.com/conductorone/baton-sdk v0.0.9
 	github.com/envoyproxy/protoc-gen-validate v0.6.13
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/pterm/pterm v0.12.49

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/conductorone/baton-sdk v0.0.6 h1:vSXlMhqJpGucV8ESt7ZgXcTqKlzAawqcek0VgWzBpT8=
-github.com/conductorone/baton-sdk v0.0.6/go.mod h1:jPdcy08LmTIPzgZcSOo7mviSAG0NUbjavg/1LpCTeOI=
+github.com/conductorone/baton-sdk v0.0.9 h1:D9Yfvh5IU061dLkbW5OvNLKrVzzGX/xS9Wequm3MJfg=
+github.com/conductorone/baton-sdk v0.0.9/go.mod h1:jPdcy08LmTIPzgZcSOo7mviSAG0NUbjavg/1LpCTeOI=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/vendor/github.com/conductorone/baton-sdk/internal/dotc1z/resources.go
+++ b/vendor/github.com/conductorone/baton-sdk/internal/dotc1z/resources.go
@@ -104,7 +104,7 @@ func (c *C1File) PutResource(ctx context.Context, resource *v2.Resource) error {
 
 	updateRecord := goqu.Record{
 		"resource_type_id": resource.Id.ResourceType,
-		"external_id":      resource.Id.Resource,
+		"external_id":      fmt.Sprintf("%s:%s", resource.Id.ResourceType, resource.Id.Resource),
 	}
 
 	if resource.ParentResourceId != nil {

--- a/vendor/github.com/conductorone/baton-sdk/internal/dotc1z/sql_helpers.go
+++ b/vendor/github.com/conductorone/baton-sdk/internal/dotc1z/sql_helpers.go
@@ -215,7 +215,7 @@ func (c *C1File) getResourceObject(ctx context.Context, resourceID *v2.ResourceI
 	q := c.db.From(resources.Name()).Prepared(true)
 	q = q.Select("data")
 	q = q.Where(goqu.C("resource_type_id").Eq(resourceID.ResourceType))
-	q = q.Where(goqu.C("external_id").Eq(resourceID.Resource))
+	q = q.Where(goqu.C("external_id").Eq(fmt.Sprintf("%s:%s", resourceID.ResourceType, resourceID.Resource)))
 
 	if c.currentSyncID != "" {
 		q = q.Where(goqu.C("sync_id").Eq(c.currentSyncID))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,7 @@ github.com/aws/smithy-go/time
 github.com/aws/smithy-go/transport/http
 github.com/aws/smithy-go/transport/http/internal/io
 github.com/aws/smithy-go/waiter
-# github.com/conductorone/baton-sdk v0.0.6
+# github.com/conductorone/baton-sdk v0.0.9
 ## explicit; go 1.19
 github.com/conductorone/baton-sdk/internal/dotc1z
 github.com/conductorone/baton-sdk/pb/c1/connector/v2


### PR DESCRIPTION
The primary fix that this has is fixing how external resource IDs are stored in the sync database. 