### PR TITLE
Update CI to produce windows artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
       - name: Checkout code
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Install Go
         if: success()
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
       - name: Checkout code
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Install Go
         if: success()
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.x
       - name: Set up Gon
         run: brew tap mitchellh/gon && brew install mitchellh/gon/gon
       - name: Import Keychain Certs
@@ -25,10 +25,10 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_SIGNING_KEY_P12 }}
           p12-password: ${{ secrets.APPLE_SIGNING_KEY_P12_PASSWORD }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.RELENG_GITHUB_TOKEN }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
@@ -40,9 +40,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20.x
       - name: Docker Login
         uses: docker/login-action@v1
         with:
@@ -52,9 +52,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist -f .goreleaser.docker.yaml
+          args: release --clean -f .goreleaser.docker.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.RELENG_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,15 @@ builds:
   - binary: baton
     env:
       - CGO_ENABLED=0
+    id: windows
+    main: ./cmd/baton
+    goos:
+      - windows
+    goarch:
+      - amd64
+  - binary: baton
+    env:
+      - CGO_ENABLED=0
     id: macos-amd64
     main: ./cmd/baton
     goos:
@@ -44,6 +53,13 @@ archives:
     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     files:
       - none*
+  - id: windows-archive
+    builds:
+      - windows
+    format: zip
+    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    files:
+      - none*
   - id: darwin-archive
     builds:
       - macos-amd64
@@ -56,11 +72,13 @@ release:
   ids:
     - linux-archive
     - darwin-archive
+    - windows-archive
 snapshot:
   name_template: '{{ incpatch .Version }}-dev'
 checksum:
   ids:
     - linux-archive
+    - windows-archive
   extra_files:
     - glob: ./dist/*-darwin-amd64.zip
     - glob: ./dist/*-darwin-arm64.zip

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OUTPUT_PATH = ${BUILD_DIR}/$(notdir $(CURDIR))
 build:
 	rm -f ${OUTPUT_PATH}
 	mkdir -p ${BUILD_DIR}
-	go build -o ${OUTPUT_PATH} cmd/baton/*.go
+	go build -o ${OUTPUT_PATH} ./cmd/baton
 
 .PHONY: update-deps
 update-deps:


### PR DESCRIPTION
On the advent of native windows support for connectors, we should produce windows binaries for `baton` as well. 