### PR TITLE
Add full list of connectors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,31 @@ We're releasing five initial connectors with the open source launch of Baton. Th
 
 Additionally, making a new connector is really easy -- we wrap up many complexities in the SDK, letting a connector developer focus on translating to the Baton data model.
 
-| Connector                | Status     |
-|--------------------------|------------|
-| [baton-aws](https://github.com/ConductorOne/baton-aws) |   GA   |
-| [baton-github](https://github.com/ConductorOne/baton-github) |   GA   |
-| [baton-mysql](https://github.com/ConductorOne/baton-mysql) |   GA   |
-| [baton-okta](https://github.com/ConductorOne/baton-okta) |   GA   |
-| [baton-postgres](https://github.com/ConductorOne/baton-postgresql) |   GA   |
+- [baton-1password](https://github.com/ConductorOne/baton-1password)
+- [baton-aws](https://github.com/ConductorOne/baton-aws)
+- [baton-asana](https://github.com/ConductorOne/baton-asana)
+- [baton-bitbucket](https://github.com/ConductorOne/baton-bitbucket)
+- [baton-box](https://github.com/ConductorOne/baton-box)
+- [baton-cloudamqp](https://github.com/ConductorOne/baton-cloudamqp)
+- [baton-duo](https://github.com/ConductorOne/baton-duo)
+- [baton-expensify](https://github.com/ConductorOne/baton-expensify)
+- [baton-github](https://github.com/ConductorOne/baton-github)
+- [baton-google-identity-platform](https://github.com/ConductorOne/baton-google-identity-platform)
+- [baton-jamf](https://github.com/ConductorOne/baton-jamf)
+- [baton-jumpcloud](https://github.com/ConductorOne/baton-jumpcloud)
+- [baton-linear](https://github.com/ConductorOne/baton-linear)
+- [baton-sql-server](https://github.com/ConductorOne/baton-sql-server)
+- [baton-mysql](https://github.com/ConductorOne/baton-mysql)
+- [baton-notion](https://github.com/ConductorOne/baton-notion)
+- [baton-okta](https://github.com/ConductorOne/baton-okta)
+- [baton-pagerduty](https://github.com/ConductorOne/baton-pagerduty)
+- [baton-panther](https://github.com/ConductorOne/baton-panther)
+- [baton-postgresql](https://github.com/ConductorOne/baton-postgresql)
+- [baton-retool](https://github.com/ConductorOne/baton-retool)
+- [baton-slack](https://github.com/ConductorOne/baton-slack)
+- [baton-splunk](https://github.com/ConductorOne/baton-splunk)
+- [baton-tableau](https://github.com/ConductorOne/baton-tableau)
+- [baton-zoom](https://github.com/ConductorOne/baton-zoom)
 
 # Learn more about Baton
 


### PR DESCRIPTION
Removed the table formatting and the "GA" notations since we aren't meaningfully using that system. 

I've made myself a note to also update the list here whenever I add new Baton connectors to the Baton docs. 