### PR TITLE
Update input for nixpkgs to unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,16 +16,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734600368,
-        "narHash": "sha256-nbG9TijTMcfr+au7ZVbKpAhMJzzE2nQBYmRvSdXUD8g=",
-        "rev": "b47fd6fa00c6afca88b8ee46cfdb00e104f50bca",
-        "revCount": 711542,
+        "lastModified": 1740560979,
+        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
+        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
+        "revCount": 759373,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.711542%2Brev-b47fd6fa00c6afca88b8ee46cfdb00e104f50bca/0193e2e7-c794-7371-ba54-67d8d646e53f/source.tar.gz?rev=b47fd6fa00c6afca88b8ee46cfdb00e104f50bca&revCount=711542"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.759373%2Brev-5135c59491985879812717f4c9fea69604e7f26f/01954717-66bd-7790-a1bd-a3f4d391b390/source.tar.gz?rev=5135c59491985879812717f4c9fea69604e7f26f&revCount=759373"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   inputs = {
     flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/*";
 
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
   };
 
   # Flake outputs that other flakes can use
@@ -45,6 +45,7 @@
             packages = with pkgs; [
               go
               buf
+
               self.packages.${pkgs.system}.default
             ];
           };
@@ -56,7 +57,7 @@
         {
           default = pkgs.buildGoModule {
             pname = "baton";
-            version = "0.1.4";
+            version = "0.1.7";
 
             src = ./.;
 


### PR DESCRIPTION
This PR fixes the following error during build time:

```
error: builder for '/nix/store/cmcslzpgbgchs8zq315vmrw1j3lbnl64-baton-0.1.4.drv' failed with exit code 1;
       last 9 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/0z18sfkb3lgqb7qm1pixlgcp437h1c2d-acw7dvfijsfnlkdgr5s1nvhh4ffqxcld-source
       > source root is acw7dvfijsfnlkdgr5s1nvhh4ffqxcld-source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > Running phase: buildPhase
       > Building subPackage ./cmd/baton
       > go: go.mod requires go >= 1.23.6 (running go 1.23.3; GOTOOLCHAIN=local)
       For full logs, run 'nix log /nix/store/cmcslzpgbgchs8zq315vmrw1j3lbnl64-baton-0.1.4.drv'.
error: 1 dependencies of derivation '/nix/store/qhz8skirybfllyz64250c5ab6j511bsk-nix-shell-env.drv' failed to build
```