### PR TITLE
Add Baton retirement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## Project status
+
+This repository has been retired. Active Baton development has moved to [ConductorOne/baton-sdk](https://github.com/ConductorOne/baton-sdk). Please use `baton-sdk` for current Baton SDK code, issues, and releases.
 
 ![Baton Logo](./docs/images/baton-logo.png)
 


### PR DESCRIPTION
Why

This repository has been retired, and visitors should be directed to the active Baton SDK repository before following older setup or contribution instructions.

What this changes

Adds a short project status notice at the top of the README that points readers to ConductorOne/baton-sdk for current Baton SDK code, issues, and releases.

Validation

- git diff --check